### PR TITLE
New names for subgrid scale contributions to momentum and tracer equations

### DIFF
--- a/dedaLES/boussinesq.py
+++ b/dedaLES/boussinesq.py
@@ -3,8 +3,12 @@ import numpy as np
 from dedalus import public as de
 
 from .flows import ChannelFlow
-from .utils import add_parameters, bind_parameters, add_first_derivative_substitutions
+from .utils import add_parameters, bind_parameters, add_substitutions, add_first_derivative_substitutions
 from .closures import add_closure_substitutions, add_closure_variables, add_closure_equations
+
+default_substitutions = {
+    'ε' : "ν*(ux*ux + uy*uy + uz*uz + vx*vx + vy*vy + vz*vz + wx*wx + wy*wy + wz*wz)"
+}
 
 class BoussinesqChannelFlow(ChannelFlow):
     """
@@ -72,6 +76,7 @@ class BoussinesqChannelFlow(ChannelFlow):
         xleft = None,  
         yleft = None,  
         zbottom = None,  
+        substitutions = default_substitutions,
         **params         
         ):
 
@@ -98,7 +103,7 @@ class BoussinesqChannelFlow(ChannelFlow):
         add_closure_equations(problem, closure, tracers=['b'])
 
         # Custom substitutions
-        problem.substitutions['ε'] = "ν*(ux*ux + uy*uy + uz*uz + vx*vx + vy*vy + vz*vz + wx*wx + wy*wy + wz*wz)"
+        add_substitutions(problem, **substitutions)
                    
         # Equations
         problem.add_equation("dt(u) - ν*(dx(ux) + dy(uy) + dz(uz)) + dx(p) - f*v = - u*ux - v*uy - w*uz + Fx_sgs")

--- a/dedaLES/boussinesq.py
+++ b/dedaLES/boussinesq.py
@@ -8,9 +8,9 @@ from .closures import add_closure_substitutions, add_closure_variables, add_clos
 
 default_substitutions = {
         'ε' : "ν*(ux*ux + uy*uy + uz*uz + vx*vx + vy*vy + vz*vz + wx*wx + wy*wy + wz*wz)",
-    'ε_sgs' : "u*Fx_sgs + v*Fy_sgs + w*Fz_sgs",
+    'ε_sgs' : "-u*(Nu_sgs+Lu_sgs) - v*(Nv_sgs+Lv_sgs) - w*(Nw_sgs+Lw_sgs)",
         'χ' : "κ*(bx*bx + by*by + bz*bz)",
-    'χ_sgs' : "b*Fb_sgs"
+    'χ_sgs' : "-b*(Nb_sgs+Lb_sgs)"
 }
 
 class BoussinesqChannelFlow(ChannelFlow):
@@ -107,12 +107,12 @@ class BoussinesqChannelFlow(ChannelFlow):
 
         # Custom substitutions
         add_substitutions(problem, **substitutions)
-                   
+
         # Equations
-        problem.add_equation("dt(u) - ν*(dx(ux) + dy(uy) + dz(uz)) + dx(p) - f*v = - u*ux - v*uy - w*uz + Fx_sgs")
-        problem.add_equation("dt(v) - ν*(dx(vx) + dy(vy) + dz(vz)) + dy(p) + f*u = - u*vx - v*vy - w*vz + Fy_sgs")
-        problem.add_equation("dt(w) - ν*(dx(wx) + dy(wy) + dz(wz)) + dz(p) - b   = - u*wx - v*wy - w*wz + Fz_sgs")
-        problem.add_equation("dt(b) - κ*(dx(bx) + dy(by) + dz(bz)) + Nsq*w = - u*bx - v*by - w*bz + Fb_sgs")
+        problem.add_equation(f"dt(u) - ν*(dx(ux) + dy(uy) + dz(uz)) + dx(p) - f*v - Lu_sgs = - u*ux - v*uy - w*uz + Nu_sgs")
+        problem.add_equation(f"dt(v) - ν*(dx(vx) + dy(vy) + dz(vz)) + dy(p) + f*u - Lv_sgs = - u*vx - v*vy - w*vz + Nv_sgs")
+        problem.add_equation(f"dt(w) - ν*(dx(wx) + dy(wy) + dz(wz)) + dz(p) - b   - Lw_sgs = - u*wx - v*wy - w*wz + Nw_sgs")
+        problem.add_equation(f"dt(b) - κ*(dx(bx) + dy(by) + dz(bz)) + Nsq*w       - Lb_sgs = - u*bx - v*by - w*bz + Nb_sgs")
         problem.add_equation("ux + vy + wz = 0")
 
         # First-order equivalencies

--- a/dedaLES/boussinesq.py
+++ b/dedaLES/boussinesq.py
@@ -96,6 +96,9 @@ class BoussinesqChannelFlow(ChannelFlow):
         # LES Closure
         add_closure_substitutions(problem, closure, tracers=['b'])
         add_closure_equations(problem, closure, tracers=['b'])
+
+        # Custom substitutions
+        problem.substitutions['ε'] = "ν*(ux*ux + uy*uy + uz*uz + vx*vx + vy*vy + vz*vz + wx*wx + wy*wy + wz*wz)"
                    
         # Equations
         problem.add_equation("dt(u) - ν*(dx(ux) + dy(uy) + dz(uz)) + dx(p) - f*v = - u*ux - v*uy - w*uz + Fx_sgs")
@@ -116,7 +119,7 @@ class BoussinesqChannelFlow(ChannelFlow):
         self.x = domain.grid(0)
         self.y = domain.grid(1)
         self.z = domain.grid(2)
-        
+
     def set_noflux_bc_top(self):
         """Set a no flux condition on buoyancy on the top wall."""
         ChannelFlow.set_tracer_noflux_bc(self, "top", tracers="b")

--- a/dedaLES/closures.py
+++ b/dedaLES/closures.py
@@ -68,7 +68,8 @@ class EddyViscosityClosure():
 
     def substitute_zero_constant_diffusivity(self, problem, tracers=[]):
         for c in tracers:
-            problem.substitutions[f'κ{c}_sgs_const'] = "0"
+            for ij in tensor_components_3d:
+                problem.substitutions[f'κ{ij}_{c}_sgs_const'] = "0"
 
     def add_substitutions_strain_rate_tensor(self, problem, u='u', v='v', w='w'):
         """
@@ -136,25 +137,26 @@ class EddyViscosityClosure():
 
         # Diffusivity for c
         κ_sgs = f"κ{c}_sgs"
-        Nc_sgs = f"N{c}_sgs"
 
         problem.substitutions[qx] = f"- {κ_sgs} * dx({c})" 
         problem.substitutions[qy] = f"- {κ_sgs} * dy({c})"
         problem.substitutions[qz] = f"- {κ_sgs} * dz({c})"
+
+        Nc_sgs = f"N{c}_sgs"
         problem.substitutions[Nc_sgs] = f"- dx({qx}) - dy({qy}) - dz({qz})"
 
         # Linear subgrid buoyancy fluxes
-        qx_linear = f"q{c}x_linear"
-        qy_linear = f"q{c}y_linear"
-        qz_linear = f"q{c}z_linear"
+        for i in ['x', 'y', 'z']:
+            qi_linear = f"q{i}_{c}_linear"
+            κix_sgs_const = f"κ{i}x_{c}_sgs_const"
+            κiy_sgs_const = f"κ{i}y_{c}_sgs_const"
+            κiz_sgs_const = f"κ{i}z_{c}_sgs_const"
+            problem.substitutions[qi_linear] = f"- {κix_sgs_const} * dx({c}) - {κiy_sgs_const} * dy({c}) - {κiz_sgs_const} * dz({c})" 
 
-        # Diffusivity for c
-        κ_sgs_const = f"κ{c}_sgs_const"
+        qx_linear = f"qx_{c}_linear"
+        qy_linear = f"qy_{c}_linear"
+        qz_linear = f"qz_{c}_linear"
         Lc_sgs = f"L{c}_sgs"
-
-        problem.substitutions[qx_linear] = f"- {κ_sgs_const} * dx({c})" 
-        problem.substitutions[qy_linear] = f"- {κ_sgs_const} * dy({c})"
-        problem.substitutions[qz_linear] = f"- {κ_sgs_const} * dz({c})"
         problem.substitutions[Lc_sgs] = f"- dx({qx_linear}) - dy({qy_linear}) - dz({qz_linear})"
 
     def add_closure_substitutions(self):

--- a/dedaLES/closures.py
+++ b/dedaLES/closures.py
@@ -1,4 +1,20 @@
+"""
+closures.py
+
+Classes and functions for implementing turbulence closures
+in dedaLES.
+
+Turbulence closures are generalized to consist of 'nonlinear' and
+'linear' momentum stress and tracer flux divergences. 
+For u-momentum, for example, the nonlinear stress divergence is 
+denoted Nu_sgs, while the linear stress divergence is denoted Lu_sgs.
+For a tracer c, the nonlinear flux divergence is Nc_sgs, and the linear
+flux divergence is Lc_sgs.
+"""
+
 import numpy as np
+
+tensor_components_3d = ['xx', 'yy', 'zz', 'xy', 'yz', 'zx', 'yx', 'zy', 'xz']
 
 def add_closure_variables(variables, closure):
     # variables = variables + closure.variables
@@ -10,29 +26,49 @@ def add_closure_substitutions(problem, closure, tracers=[], **kwargs):
     """
     if closure is None:
         # No parameterized subgrid fluxes
-        problem.substitutions['Fx_sgs'] = "0"
-        problem.substitutions['Fy_sgs'] = "0"
-        problem.substitutions['Fz_sgs'] = "0"
+        problem.substitutions['Nu_sgs'] = "0"
+        problem.substitutions['Nv_sgs'] = "0"
+        problem.substitutions['Nw_sgs'] = "0"
+        problem.substitutions['Lu_sgs'] = "0"
+        problem.substitutions['Lv_sgs'] = "0"
+        problem.substitutions['Lw_sgs'] = "0"
+        # For convenience:
+        problem.substitutions['ν_sgs'] = "0"
+        problem.substitutions['ν_sgs'] = "0"
+        problem.substitutions['ν_sgs'] = "0"
         for c in tracers:
-            problem.substitutions[f'F{c}_sgs'] = "0"
+            problem.substitutions[f'N{c}_sgs'] = "0"
+            problem.substitutions[f'L{c}_sgs'] = "0"
+            # For convenience:
+            problem.substitutions[f'κ{c}_sgs'] = "0"
     else:
         # closure.equations(problem, tracers=tracers)
         closure.add_substitutions(problem, tracers=tracers, **kwargs)
-
 
 def add_closure_equations(problem, closure, **kwargs):
     """
     Add closure equations to the problem.
     """
     pass
- 
+
 
 class EddyViscosityClosure():
     """
     Generic LES closure based on an eddy viscosity and diffusivity.
+
+    The nonlinear, isotropic eddy viscosity is denoted ν_sgs. The constant eddy 
+    viscosity tensor is denoted νij_sgs_const.
     """
     def __init__(self):
         pass
+
+    def substitute_zero_constant_viscosity(self, problem):
+        for ij in tensor_components_3d:
+            problem.substitutions[f'ν{ij}_sgs_const'] = "0"
+
+    def substitute_zero_constant_diffusivity(self, problem, tracers=[]):
+        for c in tracers:
+            problem.substitutions[f'κ{c}_sgs_const'] = "0"
 
     def add_substitutions_strain_rate_tensor(self, problem, u='u', v='v', w='w'):
         """
@@ -69,27 +105,29 @@ class EddyViscosityClosure():
 
     def add_substitutions_subgrid_stress(self, problem):
         """Defines the subgrid stress tensor `τij` and subgrid stress
-        divergence `(Fx_sgs, Fy_sgs, Fz_sgs)` in `problem`.
+        divergence `(Nu_sgs, Nv_sgs, Nw_sgs)` in `problem`.
         """
         # Subgrid stress proportional to eddy viscosity
-        problem.substitutions['τxx'] = "2 * ν_sgs * Sxx"
-        problem.substitutions['τxy'] = "2 * ν_sgs * Sxy"
-        problem.substitutions['τxz'] = "2 * ν_sgs * Sxz"
-        problem.substitutions['τyx'] = "2 * ν_sgs * Syx"
-        problem.substitutions['τyy'] = "2 * ν_sgs * Syy"
-        problem.substitutions['τyz'] = "2 * ν_sgs * Syz"
-        problem.substitutions['τzx'] = "2 * ν_sgs * Szx"
-        problem.substitutions['τzy'] = "2 * ν_sgs * Szy"
-        problem.substitutions['τzz'] = "2 * ν_sgs * Szz"
+        for ij in tensor_components_3d:
+            problem.substitutions[f'τ{ij}'] = f"2 * ν_sgs * S{ij}"
 
-        # Subgrid momentum fluxes
-        problem.substitutions['Fx_sgs'] = "dx(τxx) + dy(τyx) + dz(τzx)"
-        problem.substitutions['Fy_sgs'] = "dx(τxy) + dy(τyy) + dz(τzy)"
-        problem.substitutions['Fz_sgs'] = "dx(τxz) + dy(τyz) + dz(τzz)"
+        # Nonlinear subgrid momentum fluxes
+        problem.substitutions['Nu_sgs'] = "dx(τxx) + dy(τyx) + dz(τzx)"
+        problem.substitutions['Nv_sgs'] = "dx(τxy) + dy(τyy) + dz(τzy)"
+        problem.substitutions['Nw_sgs'] = "dx(τxz) + dy(τyz) + dz(τzz)"
 
+        # Linear terms
+        for ij in tensor_components_3d:
+            problem.substitutions[f'τ{ij}_linear'] = f"2 * ν{ij}_sgs_const * S{ij}"
+
+        # Linear subgrid momentum fluxes
+        problem.substitutions['Lu_sgs'] = "dx(τxx_linear) + dy(τyx_linear) + dz(τzx_linear)"
+        problem.substitutions['Lv_sgs'] = "dx(τxy_linear) + dy(τyy_linear) + dz(τzy_linear)"
+        problem.substitutions['Lw_sgs'] = "dx(τxz_linear) + dy(τyz_linear) + dz(τzz_linear)"
+        
     def add_substitutions_subgrid_flux(self, problem, c):
         """Defines the subgrid tracer flux for `qcx` for the tracer `c` and
-        the subgrid flux divergence `Fc_sgs` in `problem`.
+        the subgrid flux divergence `Nc_sgs` in `problem`.
         """
         # Subgrid buoyancy fluxes
         qx = f"q{c}x"
@@ -98,12 +136,26 @@ class EddyViscosityClosure():
 
         # Diffusivity for c
         κ_sgs = f"κ{c}_sgs"
-        Fc_sgs = f"F{c}_sgs"
+        Nc_sgs = f"N{c}_sgs"
 
         problem.substitutions[qx] = f"- {κ_sgs} * dx({c})" 
         problem.substitutions[qy] = f"- {κ_sgs} * dy({c})"
         problem.substitutions[qz] = f"- {κ_sgs} * dz({c})"
-        problem.substitutions[Fc_sgs] = f"- dx({qx}) - dy({qy}) - dz({qz})"
+        problem.substitutions[Nc_sgs] = f"- dx({qx}) - dy({qy}) - dz({qz})"
+
+        # Linear subgrid buoyancy fluxes
+        qx_linear = f"q{c}x_linear"
+        qy_linear = f"q{c}y_linear"
+        qz_linear = f"q{c}z_linear"
+
+        # Diffusivity for c
+        κ_sgs_const = f"κ{c}_sgs_const"
+        Lc_sgs = f"L{c}_sgs"
+
+        problem.substitutions[qx_linear] = f"- {κ_sgs_const} * dx({c})" 
+        problem.substitutions[qy_linear] = f"- {κ_sgs_const} * dy({c})"
+        problem.substitutions[qz_linear] = f"- {κ_sgs_const} * dz({c})"
+        problem.substitutions[Lc_sgs] = f"- dx({qx_linear}) - dy({qy_linear}) - dz({qz_linear})"
 
     def add_closure_substitutions(self):
         pass
@@ -142,6 +194,9 @@ class ConstantSmagorinsky(EddyViscosityClosure):
         self.Sc = Sc
 
     def add_substitutions(self, problem, tracers=[], u='u', v='v', w='w', **kwargs):
+        self.substitute_zero_constant_viscosity(problem)
+        self.substitute_zero_constant_diffusivity(problem, tracers=tracers)
+
         # Construct grid-based filter field
         Δx = problem.domain.bases[0].dealias * 2 * problem.domain.grid_spacing(0)
         Δy = problem.domain.bases[1].dealias * 2 * problem.domain.grid_spacing(1)
@@ -209,6 +264,9 @@ class AnisotropicMinimumDissipation(EddyViscosityClosure):
             tracers : list
                 A list of the names of tracers in `problem`.
         """
+        self.substitute_zero_constant_viscosity(problem)
+        self.substitute_zero_constant_diffusivity(problem, tracers=tracers)
+
         # Construct grid-based filter field
         Δx = problem.domain.bases[0].dealias * 2 * problem.domain.grid_spacing(0)
         Δy = problem.domain.bases[1].dealias * 2 * problem.domain.grid_spacing(1)

--- a/dedaLES/flows.py
+++ b/dedaLES/flows.py
@@ -189,12 +189,19 @@ class ChannelFlow(Flow):
         self.problem.add_bc("left(u) = {}".format(u))
         self.problem.add_bc("left(v) = {}".format(v))
 
-    def set_tracer_gradient_bc_bottom(self, tracers=[], gradient=0):
+    def set_tracer_value_bc_top(self, tracers=[], value=0):
         if isinstance(tracers, str):
-            self.problem.add_bc("left({}z) = {}".format(tracers, gradient))
+            self.problem.add_bc("right({}) = {}".format(tracers, gradient))
         else:
             for tracer in tracers:
-                self.problem.add_bc("left({}z) = {}".format(tracer, gradient))
+                self.problem.add_bc("right({}) = {}".format(tracer, gradient))
+
+    def set_tracer_value_bc_top(self, tracers=[], value=0):
+        if isinstance(tracers, str):
+            self.problem.add_bc("left({}) = {}".format(tracers, gradient))
+        else:
+            for tracer in tracers:
+                self.problem.add_bc("left({}) = {}".format(tracer, gradient))
 
     def set_tracer_gradient_bc_top(self, tracers=[], gradient=0):
         if isinstance(tracers, str):
@@ -202,6 +209,18 @@ class ChannelFlow(Flow):
         else:
             for tracer in tracers:
                 self.problem.add_bc("right({}z) = {}".format(tracer, gradient))
+
+    def set_tracer_gradient_bc_bottom(self, tracers=[], gradient=0):
+        if isinstance(tracers, str):
+            self.problem.add_bc("left({}z) = {}".format(tracers, gradient))
+        else:
+            for tracer in tracers:
+                self.problem.add_bc("left({}z) = {}".format(tracer, gradient))
+
+    def set_tracer_value_bc(self, tracers=[], *walls, value=0):
+        for wall in walls:
+            method = getattr(self, "set_tracer_value_bc_%s" %wall)
+            method(tracers, value=value)
 
     def set_tracer_gradient_bc(self, tracers=[], *walls, gradient=0):
         for wall in walls:
@@ -216,9 +235,11 @@ class ChannelFlow(Flow):
 
         Args
         ----
-            bctype : A string that indicates the type of boundary condition being specified.
+            bctype : (str)
+                The type of boundary condition being specified.
 
-            walls : The walls on which the boundary condition will be specified.
+            walls : (str)
+                The walls on which the boundary condition will be specified.
                     (either "top" or "bottom").
 
         Keyword args

--- a/dedaLES/flows.py
+++ b/dedaLES/flows.py
@@ -74,7 +74,7 @@ class Flow():
             except AttributeError:
                 self.log_tasks = {name: task}
 
-    def build_solver(self, timestepper='RK443'):
+    def build_solver(self, timestepper='SBDF3'):
         """Build a dedalus solver for the model with `timestepper`.
 
         Args

--- a/dedaLES/navier_stokes.py
+++ b/dedaLES/navier_stokes.py
@@ -127,9 +127,9 @@ class NavierStokesTriplyPeriodicFlow(Flow):
             linear_bg_y = "0"
             linear_bg_z = "0"
 
-        xmom = f"dt(u) + {linear_x} = - {linear_bg_x} - U*Ux - V*Uy - W*Uz + Fx_sgs"
-        ymom = f"dt(v) + {linear_y} = - {linear_bg_y} - U*Vx - V*Vy - W*Vz + Fy_sgs"
-        zmom = f"dt(w) + {linear_z} = - {linear_bg_z} - U*Wx - V*Wy - W*Wz + Fz_sgs"
+        xmom = f"dt(u) + {linear_x} + Lu_sgs = - {linear_bg_x} - U*Ux - V*Uy - W*Uz + Nu_sgs"
+        ymom = f"dt(v) + {linear_y} + Lv_sgs = - {linear_bg_y} - U*Vx - V*Vy - W*Vz + Nv_sgs"
+        zmom = f"dt(w) + {linear_z} + Lw_sgs = - {linear_bg_z} - U*Wx - V*Wy - W*Wz + Nw_sgs"
                    
         problem.add_equation(xmom)
         problem.add_equation(ymom)

--- a/dedaLES/utils.py
+++ b/dedaLES/utils.py
@@ -18,6 +18,13 @@ def add_parameters(problem, **params):
     for name, value in params.items():
         problem.parameters[name] = value
 
+def add_substitutions(problem, **substitutions):
+    """
+    Add substitutions to a dedalus problem programmatically.
+    """
+    for name, value in substitutions.items():
+        problem.substitutions[name] = value
+
 def add_first_derivative_substitutions(problem, variables, dims):
     """
     Add first-derivative substitutions for `variables` to `problem`.

--- a/examples/rayleigh_benard_example.py
+++ b/examples/rayleigh_benard_example.py
@@ -82,7 +82,7 @@ a  = 1e-3                   # Noise amplitude for initial condition
 
 # Calculated parameters
 ν = np.sqrt(Δb*Pr*Lz**3/Ra) # Viscosity. ν = sqrt(Pr/Ra) with Lz=Δb=1
-κ = Pr                      # Thermal diffusivity 
+κ = ν/Pr                      # Thermal diffusivity 
 
 # Construct model
 #closure = dedaLES.AnisotropicMinimumDissipation()

--- a/examples/rayleigh_benard_example.py
+++ b/examples/rayleigh_benard_example.py
@@ -1,3 +1,10 @@
+"""
+This script reproduces results from
+
+Robert M Kerr, "Rayleigh number scaling in numerical convection", 
+Journal of Fluid Mechanics (1996)
+"""
+
 import sys; sys.path.append("..")
 
 import time, logging
@@ -11,6 +18,38 @@ import dedaLES
 
 logger = logging.getLogger(__name__)
 
+resolutions = {
+    1: {nh:  64, nz: 32},
+    2: {nh:  96, nz: 48},
+    3: {nh: 128, nz: 48},
+    4: {nh: 192, nz: 64},
+    5: {nh: 288, nz: 96} 
+}
+
+experiments = {
+    5000: { **resolutions[1],
+            Ra : 5e4,
+            t0 : 24.0,
+            tf : 44.0 },
+    10000: { **resolutions[1],
+            Ra : 1e5,
+            t0 : 24.0,
+            tf : 44.0 },
+    20000: { **resolutions[1]
+            Ra : 2e5,
+            t0 : 24.0,
+            tf : 44.0 },
+    40000: { **resolutions[3],
+            Ra : 4e5,
+            t0 : 26.0,
+            tf : 34.0 },
+    50000: { **resolutions[2],
+            Ra : 4e5,
+            t0 : 27.0,
+            tf : 40.0 },
+} 
+            
+    
 # Domain parameters
 nx = 64         # Horizontal resolution
 ny = 64         # Horizontal resolution
@@ -21,16 +60,13 @@ Lz = 1.0        # Domain vertical extent
 
 # Parameters
 Pr = 1.0        # Prandtl number
+Ra = 2e4        # Rayleigh number
 f  = 0.0        # Coriolis parameter
-κ  = 1.0        # Thermal diffusivity 
-ε  = 0.8        # Perturbation above criticality
 a  = 1e-3       # Noise amplitude for initial condition
 
-# Constants
-Ra_critical = 1707.762
-Ra = Ra_critical + ε
-ν  = Pr*κ                   # Viscosity 
-Bz = -Ra*Pr                 # Unstable buoyancy gradient
+κ  = Pr         # Thermal diffusivity 
+Bz = -Ra*Pr     # Unstable buoyancy gradient
+ν  = 1/Re       # Viscosity 
 
 # Construct model
 closure = None #dedaLES.AnisotropicMinimumDissipation()

--- a/examples/rayleigh_benard_example.py
+++ b/examples/rayleigh_benard_example.py
@@ -28,38 +28,41 @@ resolutions = {
 }
 
 kerr_parameters = {
-    5000: { **resolutions[1],
+    5000: { 'nh' : 64,
+            'nz' : 32,
             't0' : 24.0,
             'tf' : 44.0 },
-   10000: { **resolutions[1],
+   10000: { 'nh' : 64,
+            'nz' : 32,
             't0' : 24.0,
             'tf' : 44.0 },
-   20000: { **resolutions[1]
+   20000: { 'nh' : 64,
+            'nz' : 32,
             't0' : 24.0,
-            'tf' : 44.0 },
-   40000: { **resolutions[3],
-            't0' : 26.0,
-            'tf' : 34.0 },
-   50000: { **resolutions[2],
-            't0' : 27.0,
-            'tf' : 40.0 },
-  100000: { **resolutions[3],
-            't0' : 26.0,
-            'tf' : 1000.0 },
-  250000: { **resolutions[3],
-            't0' : 26.0,
-            'tf' : 36.0 },
-  500000: { **resolutions[4],
-            't0' : 49.0,
-            'tf' : 64.0 },
- 1000000: { **resolutions[4],
-            't0' : 28.0,
-            'tf' : 37.0 },
- 2000000: { **resolutions[5],
-            't0' : 24.0,
-            'tf' : 140.0 }
-} 
-
+            'tf' : 44.0 }}
+#   40000: { **resolutions[3],
+#            't0' : 26.0,
+#            'tf' : 34.0 },
+#   50000: { **resolutions[2],
+#            't0' : 27.0,
+#            'tf' : 40.0 },
+#  100000: { **resolutions[3],
+#            't0' : 26.0,
+#            'tf' : 1000.0 },
+#  250000: { **resolutions[3],
+#            't0' : 26.0,
+#            'tf' : 36.0 },
+#  500000: { **resolutions[4],
+#            't0' : 49.0,
+#            'tf' : 64.0 },
+# 1000000: { **resolutions[4],
+#            't0' : 28.0,
+#            'tf' : 37.0 },
+# 2000000: { **resolutions[5],
+#            't0' : 24.0,
+#            'tf' : 140.0 }
+#} 
+#
     
 # Rayleigh number
 Ra = 10000
@@ -76,7 +79,7 @@ a  = 1e-3               # Noise amplitude for initial condition
 # Calculated parameters
 κ  = Pr                 # Thermal diffusivity 
 Bz = -Ra*Pr             # Unstable buoyancy gradient
-ν  = -Lz^4*Bz/(Ra*κ)    # Viscosity 
+ν  = -Lz**4*Bz/(Ra*κ)    # Viscosity 
 
 # Construct model
 closure = None #dedaLES.AnisotropicMinimumDissipation()

--- a/examples/rayleigh_benard_example.py
+++ b/examples/rayleigh_benard_example.py
@@ -83,7 +83,9 @@ a  = 1e-3                   # Noise amplitude for initial condition
 κ = Pr                      # Thermal diffusivity 
 
 # Construct model
-closure = None #dedaLES.AnisotropicMinimumDissipation()
+#closure = dedaLES.AnisotropicMinimumDissipation()
+closure = dedaLES.ConstantSmagorinsky()
+#closure = None
 model = dedaLES.BoussinesqChannelFlow(Lx=Lx, Ly=Ly, Lz=Lz, nx=nx, ny=ny, nz=nz, 
                                       ν=ν, κ=κ, Δb=Δb, closure=closure, nu=ν)
 

--- a/sandbox/pbs_cheyenne.sh
+++ b/sandbox/pbs_cheyenne.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+### Job Name
+#PBS -N test
+### Project code
+#PBS -A UMIT0023
+#PBS -l walltime=01:00:00
+#PBS -q regular
+### Merge output and error files
+#PBS -j oe
+### Select 2 nodes with 36 CPUs each for a total of 72 MPI processes
+#PBS -l select=2:ncpus=36:mpiprocs=36
+### Send email on abort, begin and end
+#PBS -m abe
+### Specify mail recipient
+#PBS -M wagner.greg@gmail.com
+
+export TMPDIR=/glade/scratch/$USER/temp
+mkdir -p $TMPDIR
+
+dedales="$HOME/dedaLES"
+examples="$dedales/examples"
+scriptname="$examples/rayleigh_benard_example.py"
+
+### Activate Miniconda
+. /glade/u/home/$USER/software/miniconda3/etc/profile.d/conda.sh
+
+conda activate dedalus
+
+module load intel/17.0.1 
+module load openmpi/3.0.1
+
+### Run the executable
+mpiexec python3 $scriptname >> test.out

--- a/sandbox/test_read_h5py.py
+++ b/sandbox/test_read_h5py.py
@@ -1,0 +1,34 @@
+import h5py
+import numpy as np
+import matplotlib.pyplot as plt
+
+filename = "snapshots/snapshots_s10/snapshots_s10_p0.h5" #
+f = h5py.File(filename, 'r')
+
+# List all groups
+n1 = len(list(f.keys()))
+print(str(n1) +' clubs')
+print()
+clubs = list(f.keys())
+print(clubs)
+# Get the data
+print('members of club 2')
+members2 = list(f[clubs[1]])
+print(list(members2))
+
+
+print('members of club 1')
+members1 = list(f[clubs[0]])
+print(members1)
+
+#output the values of all members
+for j in members1:
+    print(j)
+    print(list(f[clubs[0]][j]))
+
+#plot the horizontal component of velocity at the very last time-step
+uv = np.array(f['tasks']['u'])
+print(np.shape(uv))
+plt.pcolormesh(uv[-1], cmap='RdBu_r')
+plt.show()
+


### PR DESCRIPTION
This pull request changes the name of subgrid scale stress divergence from `Fx_sgs` (etc) to 
```
Nu_sgs
Nv_sgs
Nw_sgs
```
for momentum, and `Nc_sgs` for a tracer `c`.

It also adds linear subgrid scale terms with names `Lu_sgs`, etc, which are added to the right side of a `dedalus` equation. This permits defining eddy viscosity closures with constant viscosity tensors and eddy diffusivity closures with constant diffusivity tensors (note that 'constant' can be exchanged with 'prescribed non-constant', where non-constant coefficients are permitted on the right-side of `dedalus` equations).

There are also some miscellaneous commits associated with minor development.